### PR TITLE
added new endpoint to fetch declarations by SIREN

### DIFF
--- a/packages/api/egapro/views.py
+++ b/packages/api/egapro/views.py
@@ -166,6 +166,31 @@ async def declare(request, response, siren, year):
             emails.success.send(owners, url=url, **data)
 
 
+@tokens.require
+@app.route("/declarations/{siren}", methods=["GET"])
+async def get_declarations(request, response, siren):
+    declarations = []
+    limit = request.query.int("limit", 10)
+    years = sorted(constants.YEARS, reverse=True)
+
+    for year in years:
+        try:
+            record = await db.declaration.get(siren, year)
+
+            resource = record.as_resource()
+            if record.data.path("déclarant.nom"):
+                await helpers.patch_from_recherche_entreprises(resource["data"])
+            declarations.append(resource)
+        except:
+            pass
+        if len(declarations) == limit:
+            break
+
+    if not declarations:
+        raise HttpError(404, f"No declarations with siren {siren} for any year")
+    response.json = declarations
+
+
 @app.route("/declaration/{siren}/{year}", methods=["GET"])
 @tokens.require
 @ensure_owner


### PR DESCRIPTION
added new endpoint /declarations/SIREN to fetch all declarations for a given SIREN, with a customizable limit of 10 entries.